### PR TITLE
Pc fix backend test coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,12 +118,12 @@
                 <version>0.8.7</version>
                 <configuration>
                     <excludes>
-                        <exclude>**/edu/ucsb/cs156/example/aop/LoggingAspect.*</exclude>
-                        <exclude>**/edu/ucsb/cs156/example/config/*</exclude>
-                        <exclude>**/edu/ucsb/cs156/example/controllers/FrontendController.*</exclude>
-                        <exclude>**/edu/ucsb/cs156/example/controllers/FrontendProxyController.*</exclude>
-                        <exclude>**/edu/ucsb/cs156/example/services/CurrentUserServiceImpl.*</exclude>
-                        <exclude>**/edu/ucsb/cs156/example/ExampleApplication.*</exclude>
+                        <exclude>**/edu/ucsb/cs156/happiercows/aop/LoggingAspect.*</exclude>
+                        <exclude>**/edu/ucsb/cs156/happiercows/config/*</exclude>
+                        <exclude>**/edu/ucsb/cs156/happiercows/controllers/FrontendController.*</exclude>
+                        <exclude>**/edu/ucsb/cs156/happiercows/controllers/FrontendProxyController.*</exclude>
+                        <exclude>**/edu/ucsb/cs156/happiercows/services/CurrentUserServiceImpl.*</exclude>
+                        <exclude>**/edu/ucsb/cs156/happiercows/HappierCowsApplication.*</exclude>
                     </excludes>
                 </configuration>
                 <executions>

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommonsKey.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommonsKey.java
@@ -5,6 +5,9 @@ import java.io.Serializable;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 
+import lombok.Data;
+
+@Data
 @Embeddable
 class UserCommonsKey implements Serializable {
 
@@ -13,7 +16,4 @@ class UserCommonsKey implements Serializable {
 
     @Column(name = "user_id")
     Long userId;
-
-    // standard constructors, getters, and setters
-    // hashcode and equals implementation
 }


### PR DESCRIPTION
# Overview

In this PR, we fix test coverage issues that were caused, in part, by renaming the package from `example` to `happiercows`.

We fix the exclusions in the `pom.xml`.

We also add the `@Data` annotation to a class that didn't have it before.  This automatically generates getters, setters, etc. that don't need to be unit tested.

